### PR TITLE
AMD GPU load correction

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ const drawtypes = {
 }
 const cmd_gpu = `if [ $(command -v nvidia-smi &> /dev/null) ]; then 
 nvidia-smi --query-gpu=utilization.gpu --format=csv | sed '1d' | awk -F, '{printf "%i\\n", \$1}'; 
-else rocm-smi --alldevices --showuse --csv | sed '1d;$d' | awk -F, '{printf "%i\\n", $1}'; 
+else rocm-smi --alldevices --showuse --csv | sed '1d;$d' | awk -F, '{printf "%i\\n", $2}'; 
 fi`
 const cmd_mem = `if [ $(command -v nvidia-smi &> /dev/null) ]; then 
 nvidia-smi --query-gpu=memory.used,memory.total --format=csv | sed '1d;s/ MiB//g' | awk -F, '{printf "%i\\n", \$1/\$2*100}'; 


### PR DESCRIPTION
Small fix to extract proper number out of rocm-smi command
![image](https://github.com/wjfu99/nvidia-status-bar/assets/164964928/5eaf5d44-4b7b-4c8b-812a-15c881d28e93) <-- on AMD GPU now under load


@wjfu99 please take a look as well